### PR TITLE
Don't use a cached hadoop filesystem.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.kiwigrid</groupId>
 	<artifactId>jsr203hadoop</artifactId>
-	<version>1.0.2-KG2</version>
+	<version>1.0.2-KG3</version>
 	<name>jsr203hadoop</name>
 	<description>A Java NIO file system provider for HDFS</description>
 	<url>https://github.com/damiencarol/jsr203-hadoop</url>

--- a/src/main/java/hdfs/jsr203/HadoopFileSystem.java
+++ b/src/main/java/hdfs/jsr203/HadoopFileSystem.java
@@ -97,7 +97,8 @@ public class HadoopFileSystem extends FileSystem {
 		// Create dynamic configuration
 		Configuration conf = createConfigurationFrom(host, uriPort, env);
 
-        this.fs = org.apache.hadoop.fs.FileSystem.get(conf);
+        // don't use a shared instance since we close the DFS on close.
+        this.fs = org.apache.hadoop.fs.FileSystem.newInstance(conf);
 
         this.userPrincipalLookupService = new HadoopUserPrincipalLookupService(this);
 	}


### PR DESCRIPTION
Since it's closed if the nio.FileSystem is closed it should be shared
otherwise other users may reveice IOExceptions.
